### PR TITLE
fixed host path within binary namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "binary": {
     "module_name": "oracledb",
     "module_path": "./build/Release",
-    "host": "https://node-oracledb.s3-website-us-east-1.amazonaws.com",
+    "host": "https://s3.amazonaws.com/node-oracledb",
     "remote_path": "./{module_name}/v{version}",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   },


### PR DESCRIPTION
for whatever reason I am not able to use the path in the following format: https://node-oracledb.s3-us-east-1.amazonaws.com
instead it needs to be like this: https://s3.amazonaws.com/node-oracledb
